### PR TITLE
chore: governor bravo clean-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Create a proposal. Choose a model that fits your needs:
 
 -   [Multisig Proposal](docs/guides/multisig-proposal.md)
 -   [Timelock Proposal](docs/guides/timelock-proposal.md)
+-   [Governor Bravo Proposal](docs/guides/governor-bravo-proposal.md)
 
 ### Step 5: Implement Scripts and Tests
 

--- a/proposals/GovernorBravoProposal.sol
+++ b/proposals/GovernorBravoProposal.sol
@@ -12,11 +12,7 @@ contract GovernorBravoProposal is Proposal {
     using Address for address;
 
     /// @notice Getter function for `GovernorBravoDelegate.propose()` calldata
-    function getProposeCalldata()
-        public
-        view
-        returns (bytes memory proposeCalldata)
-    {
+    function getCalldata() public view override returns (bytes memory data)
         (
             address[] memory targets,
             uint256[] memory values,
@@ -24,7 +20,7 @@ contract GovernorBravoProposal is Proposal {
         ) = getProposalActions();
         string[] memory signatures = new string[](targets.length);
 
-        proposeCalldata = abi.encodeWithSignature(
+        data = abi.encodeWithSignature(
             "propose(address[],uint256[],string[],bytes[],string)",
             targets,
             values,
@@ -35,7 +31,7 @@ contract GovernorBravoProposal is Proposal {
 
         if (DEBUG) {
             console.log("Calldata for proposal:");
-            console.logBytes(proposeCalldata);
+            console.logBytes(data);
         }
     }
 
@@ -64,13 +60,11 @@ contract GovernorBravoProposal is Proposal {
             vm.roll(block.number + 1);
         }
 
-        bytes memory proposeCalldata = getProposeCalldata();
+        bytes memory data = getCalldata();
 
         // Register the proposal
         vm.prank(proposerAddress);
-        bytes memory data = address(payable(governorAddress)).functionCall(
-            proposeCalldata
-        );
+        bytes memory data = address(payable(governorAddress)).functionCall(data);
         uint256 proposalId = abi.decode(data, (uint256));
 
         if (DEBUG) {


### PR DESCRIPTION
- override `IProposal.getCalldata()` rather than using the custom function `getProposeCalldata()`.
- add missing link on the main readme