### PR TITLE
feat: validate sim calldata vs fork

### DIFF
--- a/examples/governor-bravo/BRAVO_01.sol
+++ b/examples/governor-bravo/BRAVO_01.sol
@@ -9,7 +9,7 @@ import {Vault} from "@examples/Vault.sol";
 // Then the proposal transfers ownership of both Vault and ERC20 to the governor address
 // Finally the proposal whitelist the ERC20 token in the Vault contract
 contract BRAVO_01 is GovernorBravoProposal {
-    // Returns the name of the proposal.
+    // Returns the proposal id.
     function id() public pure override returns (uint256) {
         return 1;
     }

--- a/examples/governor-bravo/BRAVO_01.sol
+++ b/examples/governor-bravo/BRAVO_01.sol
@@ -10,6 +10,11 @@ import {Vault} from "@examples/Vault.sol";
 // Finally the proposal whitelist the ERC20 token in the Vault contract
 contract BRAVO_01 is GovernorBravoProposal {
     // Returns the name of the proposal.
+    function id() public pure override returns (uint256) {
+        return 1;
+    }
+
+    // Returns the name of the proposal.
     function name() public pure override returns (string memory) {
         return "BRAVO_01";
     }

--- a/examples/governor-bravo/BRAVO_02.sol
+++ b/examples/governor-bravo/BRAVO_02.sol
@@ -7,7 +7,7 @@ import {MockToken} from "@examples/MockToken.sol";
 
 // Mock proposal that deposits MockToken into Vault.
 contract BRAVO_02 is GovernorBravoProposal {
-    // Returns the name of the proposal.
+    // Returns the proposal id.
     function id() public pure override returns (uint256) {
         return 2;
     }

--- a/examples/governor-bravo/BRAVO_02.sol
+++ b/examples/governor-bravo/BRAVO_02.sol
@@ -8,6 +8,11 @@ import {MockToken} from "@examples/MockToken.sol";
 // Mock proposal that deposits MockToken into Vault.
 contract BRAVO_02 is GovernorBravoProposal {
     // Returns the name of the proposal.
+    function id() public pure override returns (uint256) {
+        return 2;
+    }
+
+    // Returns the name of the proposal.
     function name() public pure override returns (string memory) {
         return "BRAVO_02";
     }

--- a/examples/governor-bravo/BRAVO_03.sol
+++ b/examples/governor-bravo/BRAVO_03.sol
@@ -8,6 +8,11 @@ import {MockToken} from "@examples/MockToken.sol";
 // Mock proposal that withdraws MockToken from Vault.
 contract BRAVO_03 is GovernorBravoProposal {
     // Returns the name of the proposal.
+    function id() public pure override returns (uint256) {
+        return 3;
+    }
+
+    // Returns the name of the proposal.
     function name() public pure override returns (string memory) {
         return "BRAVO_03";
     }

--- a/examples/governor-bravo/BRAVO_03.sol
+++ b/examples/governor-bravo/BRAVO_03.sol
@@ -7,7 +7,7 @@ import {MockToken} from "@examples/MockToken.sol";
 
 // Mock proposal that withdraws MockToken from Vault.
 contract BRAVO_03 is GovernorBravoProposal {
-    // Returns the name of the proposal.
+    // Returns the proposal id.
     function id() public pure override returns (uint256) {
         return 3;
     }

--- a/examples/timelock/TIMELOCK_01.sol
+++ b/examples/timelock/TIMELOCK_01.sol
@@ -10,11 +10,6 @@ import {Vault} from "@examples/Vault.sol";
 // Finally the proposal whitelist the ERC20 token in the Vault contract
 contract TIMELOCK_01 is TimelockProposal {
     // Returns the name of the proposal.
-    function id() public pure override returns (uint256) {
-        return 1;
-    }
-
-    // Returns the name of the proposal.
     function name() public pure override returns (string memory) {
         return "TIMELOCK_01";
     }

--- a/examples/timelock/TIMELOCK_01.sol
+++ b/examples/timelock/TIMELOCK_01.sol
@@ -10,6 +10,11 @@ import {Vault} from "@examples/Vault.sol";
 // Finally the proposal whitelist the ERC20 token in the Vault contract
 contract TIMELOCK_01 is TimelockProposal {
     // Returns the name of the proposal.
+    function id() public pure override returns (uint256) {
+        return 1;
+    }
+
+    // Returns the name of the proposal.
     function name() public pure override returns (string memory) {
         return "TIMELOCK_01";
     }
@@ -17,6 +22,11 @@ contract TIMELOCK_01 is TimelockProposal {
     // Provides a brief description of the proposal.
     function description() public pure override returns (string memory) {
         return "Timelock proposal mock";
+    }
+
+    // Returns the hash of the predecessor proposal.
+    function predecessor() public view override returns (bytes32) {
+        return bytes32(0);
     }
 
     // Deploys a vault contract and an ERC20 token contract.

--- a/examples/timelock/TIMELOCK_02.sol
+++ b/examples/timelock/TIMELOCK_02.sol
@@ -8,6 +8,11 @@ import {MockToken} from "@examples/MockToken.sol";
 // Mock proposal that deposits MockToken into Vault.
 contract TIMELOCK_02 is TimelockProposal {
     // Returns the name of the proposal.
+    function id() public pure override returns (uint256) {
+        return 2;
+    }
+
+    // Returns the name of the proposal.
     function name() public pure override returns (string memory) {
         return "TIMELOCK_02";
     }
@@ -15,6 +20,11 @@ contract TIMELOCK_02 is TimelockProposal {
     // Provides a brief description of the proposal.
     function description() public pure override returns (string memory) {
         return "Deposit MockToken into Vault";
+    }
+
+    // Returns the hash of the predecessor proposal.
+    function predecessor() public view override returns (bytes32) {
+        return bytes32(0);
     }
 
     // Sets up actions for the proposal, in this case, depositing MockToken into Vault.

--- a/examples/timelock/TIMELOCK_02.sol
+++ b/examples/timelock/TIMELOCK_02.sol
@@ -8,11 +8,6 @@ import {MockToken} from "@examples/MockToken.sol";
 // Mock proposal that deposits MockToken into Vault.
 contract TIMELOCK_02 is TimelockProposal {
     // Returns the name of the proposal.
-    function id() public pure override returns (uint256) {
-        return 2;
-    }
-
-    // Returns the name of the proposal.
     function name() public pure override returns (string memory) {
         return "TIMELOCK_02";
     }

--- a/examples/timelock/TIMELOCK_03.sol
+++ b/examples/timelock/TIMELOCK_03.sol
@@ -8,11 +8,6 @@ import {MockToken} from "@examples/MockToken.sol";
 // Mock proposal that withdraws MockToken from Vault.
 contract TIMELOCK_03 is TimelockProposal {
     // Returns the name of the proposal.
-    function id() public pure override returns (uint256) {
-        return 3;
-    }
-
-    // Returns the name of the proposal.
     function name() public pure override returns (string memory) {
         return "TIMELOCK_PROPOSAL_MOCK";
     }

--- a/examples/timelock/TIMELOCK_03.sol
+++ b/examples/timelock/TIMELOCK_03.sol
@@ -8,6 +8,11 @@ import {MockToken} from "@examples/MockToken.sol";
 // Mock proposal that withdraws MockToken from Vault.
 contract TIMELOCK_03 is TimelockProposal {
     // Returns the name of the proposal.
+    function id() public pure override returns (uint256) {
+        return 3;
+    }
+
+    // Returns the name of the proposal.
     function name() public pure override returns (string memory) {
         return "TIMELOCK_PROPOSAL_MOCK";
     }
@@ -15,6 +20,11 @@ contract TIMELOCK_03 is TimelockProposal {
     // Provides a brief description of the proposal.
     function description() public pure override returns (string memory) {
         return "Withdraw tokens from Vault";
+    }
+
+    // Returns the hash of the predecessor proposal.
+    function predecessor() public view override returns (bytes32) {
+        return bytes32(0);
     }
 
     // Sets up actions for the proposal, in this case, withdrawing MockToken into Vault.

--- a/proposals/GovernorBravoProposal.sol
+++ b/proposals/GovernorBravoProposal.sol
@@ -39,7 +39,9 @@ contract GovernorBravoProposal is Proposal {
     }
 
     /// @notice Getter function to get calldata from the proposal id of the forked environment
-    function getForkCalldata(address governor) public view returns (bytes memory data) {
+    function getForkCalldata(
+        address governor
+    ) public view returns (bytes memory data) {
         (
             address[] memory targets,
             uint[] memory values,
@@ -63,7 +65,10 @@ contract GovernorBravoProposal is Proposal {
     }
 
     // @notice Check proposal calldata against the forked environment
-    function checkCalldata(address governor, bool debug) public virtual override returns (bool) {
+    function checkCalldata(
+        address governor,
+        bool debug
+    ) public virtual override returns (bool) {
         bytes memory dataSim = getCalldata();
         bytes memory dataFork = getForkCalldata(governor);
 
@@ -161,12 +166,15 @@ contract GovernorBravoProposal is Proposal {
         require(governor.state(proposalId) == Bravo.ProposalState.Executed);
     }
 
-    function _bytesMatch(bytes memory a_, bytes memory b_) internal pure returns (bool) {
-        if(a_.length != b_.length) {
+    function _bytesMatch(
+        bytes memory a_,
+        bytes memory b_
+    ) internal pure returns (bool) {
+        if (a_.length != b_.length) {
             return false;
         }
         for (uint i = 0; i < a_.length; i++) {
-            if(a_[i] != b_[i]) {
+            if (a_[i] != b_[i]) {
                 return false;
             }
         }

--- a/proposals/GovernorBravoProposal.sol
+++ b/proposals/GovernorBravoProposal.sol
@@ -35,6 +35,30 @@ contract GovernorBravoProposal is Proposal {
         }
     }
 
+    /// @notice Getter function for `GovernorBravoDelegate.propose()` calldata
+    function getForkCalldata(address governor) public view override returns (bytes memory data) {
+        (
+            address[] memory targets,
+            uint[] memory values,
+            string[] memory signatures,
+            bytes[] memory calldatas
+        ) = GovernorBravoDelegate(governor).getActions(id());
+
+        data = abi.encodeWithSignature(
+            "propose(address[],uint256[],string[],bytes[],string)",
+            targets,
+            values,
+            signatures,
+            calldatas,
+            description()
+        );
+
+        if (DEBUG) {
+            console.log("Calldata for proposal:");
+            console.logBytes(data);
+        }
+    }
+
     /// @notice Simulate governance proposal
     /// @param governorAddress address of the Governor Bravo Delegator contract
     /// @param governanceToken address of the governance token of the system

--- a/proposals/GovernorBravoProposal.sol
+++ b/proposals/GovernorBravoProposal.sol
@@ -66,11 +66,11 @@ contract GovernorBravoProposal is Proposal {
 
     // @notice Check proposal calldata against the forked environment
     function checkCalldata(
-        address governor,
+        address check,
         bool debug
     ) public virtual override returns (bool) {
         bytes memory dataSim = getCalldata();
-        bytes memory dataFork = getForkCalldata(governor);
+        bytes memory dataFork = getForkCalldata(check);
 
         bool doMatch = _bytesMatch(dataSim, dataFork);
 

--- a/proposals/IProposal.sol
+++ b/proposals/IProposal.sol
@@ -3,6 +3,10 @@ pragma solidity ^0.8.0;
 import {Addresses} from "@addresses/Addresses.sol";
 
 interface IProposal {
+    // @notice proposal id
+    // @dev override this to set the proposal id
+    function id() external view returns (uint256);
+
     // @notice proposal name, e.g. "BIP15"
     // @dev override this to set the proposal name
     function name() external view returns (string memory);
@@ -41,6 +45,10 @@ interface IProposal {
 
     // @notice Print proposal calldata
     function getCalldata() external returns (bytes memory data);
+
+    // @notice Print proposal calldata from the forked environment
+    // @dev override this to extract the calldata for the given proposal id
+    function getForkCalldata(address governor) external returns (bytes memory data);
 
     // @notice set the debug flag
     function setDebug(bool debug) external;

--- a/proposals/IProposal.sol
+++ b/proposals/IProposal.sol
@@ -3,10 +3,6 @@ pragma solidity ^0.8.0;
 import {Addresses} from "@addresses/Addresses.sol";
 
 interface IProposal {
-    // @notice proposal id
-    // @dev override this to set the proposal id
-    function id() external view returns (uint256);
-
     // @notice proposal name, e.g. "BIP15"
     // @dev override this to set the proposal name
     function name() external view returns (string memory);
@@ -46,9 +42,8 @@ interface IProposal {
     // @notice Print proposal calldata
     function getCalldata() external returns (bytes memory data);
 
-    // @notice Print proposal calldata from the forked environment
-    // @dev override this to extract the calldata for the given proposal id
-    function getForkCalldata(address governor) external returns (bytes memory data);
+    // @notice Check proposal calldata against the forked environment
+    function checkCalldata(address check, bool debug) external returns (bool);
 
     // @notice set the debug flag
     function setDebug(bool debug) external;

--- a/proposals/Proposal.sol
+++ b/proposals/Proposal.sol
@@ -18,6 +18,9 @@ abstract contract Proposal is Test, Script, IProposal {
 
     bool internal DEBUG;
 
+    // @notice override this to set the proposal id
+    function id() public view virtual returns (uint256) {}
+
     // @notice override this to set the proposal name
     function name() external view virtual returns (string memory) {}
 
@@ -82,6 +85,9 @@ abstract contract Proposal is Test, Script, IProposal {
 
     // @notice Print proposal calldata
     function getCalldata() public virtual returns (bytes memory data) {}
+
+    // @notice Print proposal calldata from the forked environment
+    function getForkCalldata(address governor) public virtual returns (bytes memory data) {}
 
     // @notice Print out proposal actions
     // @dev do not override

--- a/proposals/Proposal.sol
+++ b/proposals/Proposal.sol
@@ -18,11 +18,8 @@ abstract contract Proposal is Test, Script, IProposal {
 
     bool internal DEBUG;
 
-    // @notice override this to set the proposal id
-    function id() public view virtual returns (uint256) {}
-
     // @notice override this to set the proposal name
-    function name() external view virtual returns (string memory) {}
+    function name() public view virtual returns (string memory) {}
 
     // @notice override this to set the proposal description
     function description() public view virtual returns (string memory) {}
@@ -86,8 +83,8 @@ abstract contract Proposal is Test, Script, IProposal {
     // @notice Print proposal calldata
     function getCalldata() public virtual returns (bytes memory data) {}
 
-    // @notice Print proposal calldata from the forked environment
-    function getForkCalldata(address governor) public virtual returns (bytes memory data) {}
+    // @notice Check proposal calldata against the forked environment
+    function checkCalldata(address check, bool debug) public virtual returns (bool) {}
 
     // @notice Print out proposal actions
     // @dev do not override

--- a/proposals/Proposal.sol
+++ b/proposals/Proposal.sol
@@ -84,7 +84,10 @@ abstract contract Proposal is Test, Script, IProposal {
     function getCalldata() public virtual returns (bytes memory data) {}
 
     // @notice Check proposal calldata against the forked environment
-    function checkCalldata(address check, bool debug) public virtual returns (bool) {}
+    function checkCalldata(
+        address check,
+        bool debug
+    ) public virtual returns (bool) {}
 
     // @notice Print out proposal actions
     // @dev do not override

--- a/proposals/TimelockProposal.sol
+++ b/proposals/TimelockProposal.sol
@@ -69,7 +69,10 @@ abstract contract TimelockProposal is Proposal {
     }
 
     // @notice Check proposal calldata against the forked environment
-    function checkCalldata(address timelock, bool debug) public view override returns (bool) {
+    function checkCalldata(
+        address timelock,
+        bool debug
+    ) public view override returns (bool) {
         bytes32 salt = keccak256(abi.encode(actions[0].description));
 
         (
@@ -78,9 +81,13 @@ abstract contract TimelockProposal is Proposal {
             bytes[] memory payloads
         ) = getProposalActions();
 
-        bytes32 id = keccak256(abi.encode(targets, values, payloads, predecessor(), salt));
-        
-        bool doMatch = TimelockController(payable(timelock)).isOperationPending(id);
+        bytes32 id = keccak256(
+            abi.encode(targets, values, payloads, predecessor(), salt)
+        );
+
+        bool doMatch = TimelockController(payable(timelock)).isOperationPending(
+            id
+        );
         if (debug) {
             console.log("Proposal name:", name());
             if (doMatch) {

--- a/proposals/TimelockProposal.sol
+++ b/proposals/TimelockProposal.sol
@@ -8,12 +8,13 @@ import {Address} from "@utils/Address.sol";
 abstract contract TimelockProposal is Proposal {
     using Address for address;
 
+    function predecessor() public view virtual returns (bytes32) {}
+
     /// @notice get schedule calldata
     function getScheduleCalldata(
         address timelock
     ) public view returns (bytes memory scheduleCalldata) {
         bytes32 salt = keccak256(abi.encode(actions[0].description));
-        bytes32 predecessor = bytes32(0);
 
         (
             address[] memory targets,
@@ -27,7 +28,7 @@ abstract contract TimelockProposal is Proposal {
             targets,
             values,
             payloads,
-            predecessor,
+            predecessor(),
             salt,
             delay
         );
@@ -45,7 +46,6 @@ abstract contract TimelockProposal is Proposal {
         returns (bytes memory executeCalldata)
     {
         bytes32 salt = keccak256(abi.encode(actions[0].description));
-        bytes32 predecessor = bytes32(0);
 
         (
             address[] memory targets,
@@ -58,7 +58,7 @@ abstract contract TimelockProposal is Proposal {
             targets,
             values,
             payloads,
-            predecessor,
+            predecessor(),
             salt
         );
 

--- a/proposals/TimelockProposal.sol
+++ b/proposals/TimelockProposal.sol
@@ -82,11 +82,23 @@ abstract contract TimelockProposal is Proposal {
         ) = getProposalActions();
 
         TimelockController timelock = TimelockController(payable(check));
-        bytes32 id = timelock.hashOperationBatch(targets, values, payloads, predecessor(), salt);
+        bytes32 id = timelock.hashOperationBatch(
+            targets,
+            values,
+            payloads,
+            predecessor(),
+            salt
+        );
         bool doMatch = timelock.isOperationPending(id);
         // If there is only one action, check if it matches the hash of a single operation
         if (targets.length == 1 && !doMatch) {
-            id = timelock.hashOperation(targets[0], values[0], payloads[0], predecessor(), salt);
+            id = timelock.hashOperation(
+                targets[0],
+                values[0],
+                payloads[0],
+                predecessor(),
+                salt
+            );
             doMatch = timelock.isOperation(id);
         }
 

--- a/script/ScriptSuite.s.sol
+++ b/script/ScriptSuite.s.sol
@@ -26,4 +26,25 @@ contract ScriptSuite is Script {
             console.log(recordedNames[j], recordedAddresses[j]);
         }
     }
+
+    function checkProposalCalldatas(
+        address check
+    ) public returns (bool[] memory calldataMatches) {
+        if (debug) {
+            console.log(
+                "TestSuite: comparing calldata for",
+                proposals.length,
+                "proposals."
+            );
+        }
+
+        calldataMatches = new bool[](proposals.length);
+
+        for (uint256 i = 0; i < proposals.length; i++) {
+            bool doMatch = proposals[i].checkCalldata(check, debug);
+            calldataMatches[i] = doMatch;
+        }
+
+        return calldataMatches;
+    }
 }

--- a/script/ScriptSuite.s.sol
+++ b/script/ScriptSuite.s.sol
@@ -29,22 +29,8 @@ contract ScriptSuite is Script {
 
     function checkProposalCalldatas(
         address check
-    ) public returns (bool[] memory calldataMatches) {
-        if (debug) {
-            console.log(
-                "TestSuite: comparing calldata for",
-                proposals.length,
-                "proposals."
-            );
-        }
-
-        calldataMatches = new bool[](proposals.length);
-
-        for (uint256 i = 0; i < proposals.length; i++) {
-            bool doMatch = proposals[i].checkCalldata(check, debug);
-            calldataMatches[i] = doMatch;
-        }
-
-        return calldataMatches;
+    ) public returns (bool calldataMatches) {
+        console.log("Comparing calldata for proposal vs forked environment.");
+        return proposal.checkCalldata(check, true);
     }
 }

--- a/test/GovernorBravoPostProposalCheck.sol
+++ b/test/GovernorBravoPostProposalCheck.sol
@@ -18,6 +18,7 @@ contract GovernorBravoPostProposalCheck is Test {
     string public constant ADDRESSES_PATH = "./addresses/Addresses.json";
     TestSuite public suite;
     Addresses public addresses;
+    bool public checkCalldata;
 
     function setUp() public virtual {
         BRAVO_01 governorProposal1 = new BRAVO_01();
@@ -42,7 +43,8 @@ contract GovernorBravoPostProposalCheck is Test {
             // retrieve the size of the code, this needs assembly
             governorSize := extcodesize(governor)
         }
-        if (governorSize == 0) {
+        if (governorSize != 0) checkCalldata = true;
+        else {
             address govToken = addresses.getAddress(
                 "PROTOCOL_GOVERNANCE_TOKEN"
             );

--- a/test/TestSuite.t.sol
+++ b/test/TestSuite.t.sol
@@ -8,7 +8,7 @@ import {Test} from "@forge-std/Test.sol";
 
 /*
 How to use:
-forge test --fork-url $ETH_RPC_URL --match-contract -vvv
+forge test --fork-url $ETH_RPC_URL --doMatch-contract -vvv
 
 Or, from another Solidity file (for post-proposal integration testing):
     TestSuite suite = new TestSuite();
@@ -78,55 +78,18 @@ contract TestSuite is Test {
         return postProposalVmSnapshots;
     }
 
-    function checkProposalCalldatas(address governor) public returns (bool[] memory calldataMatches) {
+    function checkProposalCalldatas(address check) public returns (bool[] memory calldataMatches) {
         if (debug) {
-            console.log("TestSuite: comparing", proposals.length, "proposals.");
+            console.log("TestSuite: comparing calldata for", proposals.length, "proposals.");
         }
 
-        /// evm snapshot array
         calldataMatches = new bool[](proposals.length);
 
         for (uint256 i = 0; i < proposals.length; i++) {
-            string memory name = proposals[i].name();
-            if (debug) {
-                console.log("Proposal id:", proposals[i].id());
-                console.log("Proposal name:", name);
-            }
-
-            bytes memory dataSim = proposals[i].getCalldata();
-            bytes memory dataFork = proposals[i].getForkCalldata(governor);
-            bool check = _bytesMatch(dataSim, dataFork);
-
-            if (debug) {
-                if (check) {
-                    console.log(
-                        "  > Simulated calldata matches proposal id %s in the forked environment",
-                        proposals[i].id()
-                    );
-                } else {
-                    console.log(
-                        "  x Simulated calldata does not match proposal id %s in the forked environment",
-                        proposals[i].id()
-                    );
-                }
-            }
-
-            calldataMatches[i] = check;
+            bool doMatch =  proposals[i].checkCalldata(check, debug);
+            calldataMatches[i] = doMatch;
         }
 
         return calldataMatches;
     }
-
-    function _bytesMatch(bytes memory a_, bytes memory b_) internal pure returns (bool) {
-        if(a_.length != b_.length) {
-            return false;
-        }
-        for (uint i = 0; i < a_.length; i++) {
-            if(a_[i] != b_[i]) {
-                return false;
-            }
-        }
-        return true;
-    }
-
 }

--- a/test/TestSuite.t.sol
+++ b/test/TestSuite.t.sol
@@ -77,4 +77,56 @@ contract TestSuite is Test {
 
         return postProposalVmSnapshots;
     }
+
+    function checkProposalCalldatas(address governor) public returns (bool[] memory calldataMatches) {
+        if (debug) {
+            console.log("TestSuite: comparing", proposals.length, "proposals.");
+        }
+
+        /// evm snapshot array
+        calldataMatches = new bool[](proposals.length);
+
+        for (uint256 i = 0; i < proposals.length; i++) {
+            string memory name = proposals[i].name();
+            if (debug) {
+                console.log("Proposal id:", proposals[i].id());
+                console.log("Proposal name:", name);
+            }
+
+            bytes memory dataSim = proposals[i].getCalldata();
+            bytes memory dataFork = proposals[i].getForkCalldata(governor);
+            bool check = _bytesMatch(dataSim, dataFork);
+
+            if (debug) {
+                if (check) {
+                    console.log(
+                        "  > Simulated calldata matches proposal id %s in the forked environment",
+                        proposals[i].id()
+                    );
+                } else {
+                    console.log(
+                        "  x Simulated calldata does not match proposal id %s in the forked environment",
+                        proposals[i].id()
+                    );
+                }
+            }
+
+            calldataMatches[i] = check;
+        }
+
+        return calldataMatches;
+    }
+
+    function _bytesMatch(bytes memory a_, bytes memory b_) internal pure returns (bool) {
+        if(a_.length != b_.length) {
+            return false;
+        }
+        for (uint i = 0; i < a_.length; i++) {
+            if(a_[i] != b_[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
 }

--- a/test/TestSuite.t.sol
+++ b/test/TestSuite.t.sol
@@ -8,7 +8,7 @@ import {Test} from "@forge-std/Test.sol";
 
 /*
 How to use:
-forge test --fork-url $ETH_RPC_URL --doMatch-contract -vvv
+forge test --fork-url $ETH_RPC_URL --match-contract -vvv
 
 Or, from another Solidity file (for post-proposal integration testing):
     TestSuite suite = new TestSuite();
@@ -78,15 +78,21 @@ contract TestSuite is Test {
         return postProposalVmSnapshots;
     }
 
-    function checkProposalCalldatas(address check) public returns (bool[] memory calldataMatches) {
+    function checkProposalCalldatas(
+        address check
+    ) public returns (bool[] memory calldataMatches) {
         if (debug) {
-            console.log("TestSuite: comparing calldata for", proposals.length, "proposals.");
+            console.log(
+                "TestSuite: comparing calldata for",
+                proposals.length,
+                "proposals."
+            );
         }
 
         calldataMatches = new bool[](proposals.length);
 
         for (uint256 i = 0; i < proposals.length; i++) {
-            bool doMatch =  proposals[i].checkCalldata(check, debug);
+            bool doMatch = proposals[i].checkCalldata(check, debug);
             calldataMatches[i] = doMatch;
         }
 

--- a/test/TimelockPostProposalCheck.sol
+++ b/test/TimelockPostProposalCheck.sol
@@ -14,6 +14,7 @@ contract TimelockPostProposalCheck is Test {
     string public constant ADDRESSES_PATH = "./addresses/Addresses.json";
     TestSuite public suite;
     Addresses public addresses;
+    bool public checkCalldata;
 
     function setUp() public {
         TIMELOCK_01 timelockProposal = new TIMELOCK_01();
@@ -39,7 +40,8 @@ contract TimelockPostProposalCheck is Test {
             // retrieve the size of the code, this needs assembly
             timelockSize := extcodesize(timelock)
         }
-        if (timelockSize == 0) {
+        if (timelockSize != 0) checkCalldata = true;
+        else {
             // Get proposer and executor addresses
             address proposer = addresses.getAddress("TIMELOCK_PROPOSER");
             address executor = addresses.getAddress("TIMELOCK_EXECUTOR");

--- a/test/integration/GovernorBravoProposal.t.sol
+++ b/test/integration/GovernorBravoProposal.t.sol
@@ -9,6 +9,18 @@ import "@forge-std/Test.sol";
 // the ability to interact with state modifications effected by proposals
 // and to work with newly deployed contracts, if applicable.
 contract GovernorBravoProposalTest is GovernorBravoPostProposalCheck {
+
+    // Check if simulated calldatas match the ones from the forked environment.
+    function test_calldataMatch() public {
+        address governor = addresses.getAddress("PROTOCOL_GOVERNOR");
+        bool[] memory matches = suite.checkProposalCalldatas(governor);
+        if (checkCalldata) {
+            for (uint256 i; i < matches.length; i++) {
+                assertTrue(matches[i]);
+            }
+        }
+    }
+
     function test_vaultIsPausable() public {
         Vault timelockVault = Vault(addresses.getAddress("VAULT"));
         address timelock = addresses.getAddress("PROTOCOL_TIMELOCK");

--- a/test/integration/GovernorBravoProposal.t.sol
+++ b/test/integration/GovernorBravoProposal.t.sol
@@ -9,7 +9,6 @@ import "@forge-std/Test.sol";
 // the ability to interact with state modifications effected by proposals
 // and to work with newly deployed contracts, if applicable.
 contract GovernorBravoProposalTest is GovernorBravoPostProposalCheck {
-
     // Check if simulated calldatas match the ones from the forked environment.
     function test_calldataMatch() public {
         address governor = addresses.getAddress("PROTOCOL_GOVERNOR");
@@ -18,6 +17,8 @@ contract GovernorBravoProposalTest is GovernorBravoPostProposalCheck {
             for (uint256 i; i < matches.length; i++) {
                 assertTrue(matches[i]);
             }
+        } else {
+            console2.log("Skipping calldata check");
         }
     }
 

--- a/test/integration/TimelockProposal.t.sol
+++ b/test/integration/TimelockProposal.t.sol
@@ -9,6 +9,19 @@ import "@forge-std/Test.sol";
 // the ability to interact with state modifications effected by proposals
 // and to work with newly deployed contracts, if applicable.
 contract TimelockProposalTest is TimelockPostProposalCheck {
+    // Check if simulated calldatas match the ones from the forked environment.
+    function test_calldataMatch() public {
+        address timelock = addresses.getAddress("PROTOCOL_TIMELOCK");
+        bool[] memory matches = suite.checkProposalCalldatas(timelock);
+        if (checkCalldata) {
+            for (uint256 i; i < matches.length; i++) {
+                assertTrue(matches[i]);
+            }
+        } else {
+            console2.log("Skipping calldata check");
+        }
+    }
+
     function test_vaultIsPausable() public {
         Vault timelockVault = Vault(addresses.getAddress("VAULT"));
         address timelock = addresses.getAddress("PROTOCOL_TIMELOCK");


### PR DESCRIPTION
This PR aims to introduce a way to validate proposal actions vs the ones currently submitted on-chain.
To do so, a couple of new functions have been added:
- `Proposal.checkCalldata(address check, bool debug)`: function in the proposal contract and overridden by each custom implementation. Checks that the actions in the proposal simulator match the ones submitted on chain.
   - `check`: address of the contract that holds the governance state.
   - `debug`: whether to print logs or not.
- `TestSuite.checkProposalCalldatas(address check)`: test function to run the calldata check for each proposal in the test suite.
   - `check`: address of the contract that holds the governance state.

The usage idea that i had is that users who want to use this feature, can write their own integration tests.