### PR TITLE
Update forge-std to v1.16.2

### DIFF
--- a/mocks/MockERC20.sol
+++ b/mocks/MockERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.6.2 <0.9.0;
+pragma solidity ^0.8.0;
 
 import {IERC20} from "forge-std/interfaces/IERC20.sol";
 

--- a/mocks/MockERC20.sol
+++ b/mocks/MockERC20.sol
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.2 <0.9.0;
+
+import {IERC20} from "forge-std/interfaces/IERC20.sol";
+
+/// @notice This is a mock contract of the ERC20 standard for testing purposes only, it SHOULD NOT be used in production.
+/// @dev Forked from: https://github.com/transmissions11/solmate/blob/0384dbaaa4fcb5715738a9254a7c0a4cb62cf458/src/tokens/ERC20.sol
+contract MockERC20 is IERC20 {
+    /*//////////////////////////////////////////////////////////////
+                            METADATA STORAGE
+    //////////////////////////////////////////////////////////////*/
+
+    string internal _name;
+
+    string internal _symbol;
+
+    uint8 internal _decimals;
+
+    function name() external view override returns (string memory) {
+        return _name;
+    }
+
+    function symbol() external view override returns (string memory) {
+        return _symbol;
+    }
+
+    function decimals() external view override returns (uint8) {
+        return _decimals;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                              ERC20 STORAGE
+    //////////////////////////////////////////////////////////////*/
+
+    uint256 internal _totalSupply;
+
+    mapping(address => uint256) internal _balanceOf;
+
+    mapping(address => mapping(address => uint256)) internal _allowance;
+
+    function totalSupply() external view override returns (uint256) {
+        return _totalSupply;
+    }
+
+    function balanceOf(address owner) external view override returns (uint256) {
+        return _balanceOf[owner];
+    }
+
+    function allowance(address owner, address spender)
+        external
+        view
+        override
+        returns (uint256)
+    {
+        return _allowance[owner][spender];
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            EIP-2612 STORAGE
+    //////////////////////////////////////////////////////////////*/
+
+    uint256 internal INITIAL_CHAIN_ID;
+
+    bytes32 internal INITIAL_DOMAIN_SEPARATOR;
+
+    mapping(address => uint256) public nonces;
+
+    /*//////////////////////////////////////////////////////////////
+                               INITIALIZE
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev A bool to track whether the contract has been initialized.
+    bool private initialized;
+
+    /// @dev To hide constructor warnings across solc versions due to different constructor visibility requirements and
+    /// syntaxes, we add an initialization function that can be called only once.
+    function initialize(
+        string memory name_,
+        string memory symbol_,
+        uint8 decimals_
+    ) public {
+        require(!initialized, "ALREADY_INITIALIZED");
+
+        _name = name_;
+        _symbol = symbol_;
+        _decimals = decimals_;
+
+        INITIAL_CHAIN_ID = _pureChainId();
+        INITIAL_DOMAIN_SEPARATOR = computeDomainSeparator();
+
+        initialized = true;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                               ERC20 LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    function approve(address spender, uint256 amount)
+        public
+        virtual
+        override
+        returns (bool)
+    {
+        _allowance[msg.sender][spender] = amount;
+
+        emit Approval(msg.sender, spender, amount);
+
+        return true;
+    }
+
+    function transfer(address to, uint256 amount)
+        public
+        virtual
+        override
+        returns (bool)
+    {
+        _balanceOf[msg.sender] = _sub(_balanceOf[msg.sender], amount);
+        _balanceOf[to] = _add(_balanceOf[to], amount);
+
+        emit Transfer(msg.sender, to, amount);
+
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount)
+        public
+        virtual
+        override
+        returns (bool)
+    {
+        uint256 allowed = _allowance[from][msg.sender]; // Saves gas for limited approvals.
+
+        if (allowed != ~uint256(0)) {
+            _allowance[from][msg.sender] = _sub(allowed, amount);
+        }
+
+        _balanceOf[from] = _sub(_balanceOf[from], amount);
+        _balanceOf[to] = _add(_balanceOf[to], amount);
+
+        emit Transfer(from, to, amount);
+
+        return true;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                             EIP-2612 LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public virtual {
+        require(deadline >= block.timestamp, "PERMIT_DEADLINE_EXPIRED");
+
+        address recoveredAddress = ecrecover(
+            keccak256(
+                abi.encodePacked(
+                    "\x19\x01",
+                    DOMAIN_SEPARATOR(),
+                    keccak256(
+                        abi.encode(
+                            keccak256(
+                                "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
+                            ),
+                            owner,
+                            spender,
+                            value,
+                            nonces[owner]++,
+                            deadline
+                        )
+                    )
+                )
+            ),
+            v,
+            r,
+            s
+        );
+
+        require(
+            recoveredAddress != address(0) && recoveredAddress == owner,
+            "INVALID_SIGNER"
+        );
+
+        _allowance[recoveredAddress][spender] = value;
+
+        emit Approval(owner, spender, value);
+    }
+
+    function DOMAIN_SEPARATOR() public view virtual returns (bytes32) {
+        return _pureChainId() == INITIAL_CHAIN_ID
+            ? INITIAL_DOMAIN_SEPARATOR
+            : computeDomainSeparator();
+    }
+
+    function computeDomainSeparator() internal view virtual returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                keccak256(
+                    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+                ),
+                keccak256(bytes(_name)),
+                keccak256("1"),
+                _pureChainId(),
+                address(this)
+            )
+        );
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        INTERNAL MINT/BURN LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    function _mint(address to, uint256 amount) internal virtual {
+        _totalSupply = _add(_totalSupply, amount);
+        _balanceOf[to] = _add(_balanceOf[to], amount);
+
+        emit Transfer(address(0), to, amount);
+    }
+
+    function _burn(address from, uint256 amount) internal virtual {
+        _balanceOf[from] = _sub(_balanceOf[from], amount);
+        _totalSupply = _sub(_totalSupply, amount);
+
+        emit Transfer(from, address(0), amount);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        INTERNAL SAFE MATH LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    function _add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "ERC20: addition overflow");
+        return c;
+    }
+
+    function _sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        require(a >= b, "ERC20: subtraction underflow");
+        return a - b;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                                HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    function _viewChainId() private view returns (uint256 chainId) {
+        assembly {
+            chainId := chainid()
+        }
+
+        address(this); // Silence warnings in older Solc versions.
+    }
+
+    function _pureChainId() private pure returns (uint256 chainId) {
+        function() internal view returns (uint256) fnIn = _viewChainId;
+        function() internal pure returns (uint256) pureChainId;
+        assembly {
+            pureChainId := fnIn
+        }
+        chainId = pureChainId();
+    }
+}

--- a/mocks/MockToken.sol
+++ b/mocks/MockToken.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "forge-std/mocks/MockERC20.sol";
+import "@mocks/MockERC20.sol";
 
 /// @notice This is a mock contract for testing purposes only, it SHOULD NOT be used in production.
 contract MockToken is MockERC20 {

--- a/src/proposals/Proposal.sol
+++ b/src/proposals/Proposal.sol
@@ -336,7 +336,7 @@ abstract contract Proposal is Test, Script, IProposal {
     function _startBuild(address toPrank) private {
         vm.startPrank(toPrank);
 
-        _startSnapshot = vm.snapshot();
+        _startSnapshot = vm.snapshotState();
 
         vm.startStateDiffRecording();
     }
@@ -355,7 +355,7 @@ abstract contract Proposal is Test, Script, IProposal {
 
         /// roll back all state changes made during the governance proposal
         require(
-            vm.revertTo(_startSnapshot),
+            vm.revertToState(_startSnapshot),
             "failed to revert back to snapshot, unsafe state to run proposal"
         );
 

--- a/test/multisigProposals/MultisigProposal_03.sol
+++ b/test/multisigProposals/MultisigProposal_03.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "forge-std/mocks/MockERC20.sol";
+import "@mocks/MockERC20.sol";
 
 import {MockVotingContract} from "mocks/MockVotingContract.sol";
 

--- a/test/multisigProposals/MultisigProposal_04.sol
+++ b/test/multisigProposals/MultisigProposal_04.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "forge-std/mocks/MockERC20.sol";
+import "@mocks/MockERC20.sol";
 
 import {MockAuction} from "mocks/MockAuction.sol";
 

--- a/test/multisigProposals/MultisigProposal_05.sol
+++ b/test/multisigProposals/MultisigProposal_05.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "forge-std/mocks/MockERC20.sol";
+import "@mocks/MockERC20.sol";
 
 import {MockSavingContract} from "mocks/MockSavingContract.sol";
 


### PR DESCRIPTION
## Summary
- Update forge-std submodule from v1.8.1 to v1.16.2
- Migrate snapshot API: `vm.snapshot()` → `vm.snapshotState()`, `vm.revertTo()` → `vm.revertToState()`
- Vendor `MockERC20.sol` into `mocks/` since forge-std removed its `mocks/` directory

## Test plan
- [x] `forge build` compiles clean
- [x] `forge test` — all 62 tests pass